### PR TITLE
Fixed index_patterns key

### DIFF
--- a/src/Persistence/Command.php
+++ b/src/Persistence/Command.php
@@ -363,7 +363,7 @@ class Command
     public function createTemplate($name, $pattern, $settings, $mappings, $order = 0)
     {
         $body = \json_encode([
-            'template' => $pattern,
+            'index_patterns' => $pattern,
             'order' => $order,
             'settings' => (object) $settings,
             'mappings' => (object) $mappings,


### PR DESCRIPTION
Fix of the current error:
```
{"error":{"root_cause":[{"type":"action_request_validation_exception","reason":"Validation Failed: 1: index patterns are missing;"}],"type":"action_request_validation_exception","reason":"Validation Failed: 1: index patterns are missing;"},"status":400}
```

In accordance to the docs:
https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html